### PR TITLE
添加 EVC Team Relay MCP 到 AI 辅助分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 | ------------------------------------------------------------------------------- | --------- | ------------------------------ |
 | [GPT-LiteInquirer](https://github.com/ittuann/obsidian-gpt-liteinquirer-plugin) | `ittuann` | 在 Obsidian 中集成轻量级的 ChatGPT 助手。 |
 | [Tars](https://github.com/TarsLab/obsidian-tars)                                | `TarsLab` | 基于笔记标签和上下文，提供智能文本生成建议。         |
+| [EVC Team Relay MCP](https://github.com/entire-vc/evc-team-relay-mcp)                    | `entire-vc` | 通过 MCP 协议让 AI 编程工具直接读写 Obsidian 笔记库。 |
 
 ### 数据同步与集成
 


### PR DESCRIPTION
## 添加 EVC Team Relay MCP

在 AI 辅助分类下添加 [EVC Team Relay MCP](https://github.com/entire-vc/evc-team-relay-mcp)。

**功能:** 通过 MCP (Model Context Protocol) 协议让 AI 编程工具 (Claude Code, Cursor, Windsurf, Codex) 直接读写 Obsidian 笔记库中的文档。

**工具:** list_shares, list_files, read_file, upsert_file, write_document, delete_file

**安装:** `uvx evc-team-relay-mcp` (PyPI)

**相关链接:**
- 仓库: https://github.com/entire-vc/evc-team-relay-mcp
- PyPI: https://pypi.org/project/evc-team-relay-mcp/
- 主页: https://entire.vc/team-relay/